### PR TITLE
Added support for AsTask()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages/
 *~
 .gradle/
 TestResult.xml
+.idea/

--- a/CreateAR.Commons.Unity.Async.Test/AsyncToken_Tests.cs
+++ b/CreateAR.Commons.Unity.Async.Test/AsyncToken_Tests.cs
@@ -493,6 +493,29 @@ namespace CreateAR.Commons.Unity.Async
         }
 
         [Test]
+        public async Task TaskTimeout()
+        {
+            var token = new AsyncToken<float>();
+
+            Exception callbackException = null;
+            token.OnFailure(exception => callbackException = exception);
+            
+            var task = token.AsTask(5000);
+            var taskSuccess = false;
+            
+            try
+            {
+                await task;
+                taskSuccess = true;
+            }
+            catch (Exception exception)
+            {
+                Assert.IsTrue(exception is TimeoutException);
+            }
+            Assert.IsFalse(taskSuccess);
+        }
+
+        [Test]
         public void Token()
         {
             var token = new AsyncToken<TestResult>();

--- a/CreateAR.Commons.Unity.Async.Test/AsyncToken_Tests.cs
+++ b/CreateAR.Commons.Unity.Async.Test/AsyncToken_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace CreateAR.Commons.Unity.Async
@@ -416,6 +417,79 @@ namespace CreateAR.Commons.Unity.Async
             token.Succeed(new TestResult());
 
             Assert.IsTrue(called);
+        }
+
+        [Test]
+        public async Task TaskSuccess()
+        {
+            var token = new AsyncToken<float>();
+
+            var callbackResult = 0f;
+            token.OnSuccess(val => callbackResult = val);
+
+            var taskResult = 0f;
+            var task = token
+                .AsTask()
+                .ContinueWith(cTask =>
+                {
+                    taskResult = cTask.Result;
+                });
+
+            var expectedValue = 2.26f;
+            
+            token.Succeed(expectedValue);
+            await task;
+            
+            Assert.AreEqual(expectedValue, callbackResult);
+            Assert.AreEqual(expectedValue, taskResult);
+        }
+        
+        [Test]
+        public async Task TaskFail()
+        {
+            var token = new AsyncToken<float>();
+
+            Exception callbackException = null;
+            token.OnFailure(exception => callbackException = exception);
+            
+            var task = token.AsTask();
+
+            var expectedException = new InvalidOperationException("Test exception");
+            token.Fail(expectedException);
+
+            try
+            {
+                await task;
+            }
+            catch (Exception exception)
+            {
+                Assert.AreEqual(expectedException, exception);
+            }
+            Assert.AreEqual(expectedException, callbackException);
+        }
+        
+        [Test]
+        public async Task TaskAborted()
+        {
+            var token = new AsyncToken<float>();
+
+            Exception callbackException = null;
+            token.OnFailure(exception => callbackException = exception);
+            
+            var task = token.AsTask();
+            var taskSuccess = false;
+            token.Abort();
+            
+            try
+            {
+                await task;
+                taskSuccess = true;
+            }
+            catch (Exception exception)
+            {
+                Assert.IsTrue(exception is OperationCanceledException);
+            }
+            Assert.IsFalse(taskSuccess);
         }
 
         [Test]

--- a/CreateAR.Commons.Unity.Async.Test/CreateAR.Commons.Unity.Async.Test.csproj
+++ b/CreateAR.Commons.Unity.Async.Test/CreateAR.Commons.Unity.Async.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35</TargetFrameworks>
     <RootNamespace>CreateAR.Commons.Unity.Async</RootNamespace>
     <AssemblyName>CreateAR.Commons.Unity.Async.Test</AssemblyName>
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CreateAR.Commons.Unity.Async/AsyncToken.cs
+++ b/CreateAR.Commons.Unity.Async/AsyncToken.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CreateAR.Commons.Unity.Async
 {
@@ -196,6 +198,27 @@ namespace CreateAR.Commons.Unity.Async
             OnFailure(output.Fail);
 
             return output;
+        }
+        
+        /// <inheritdoc cref="IAsyncToken{T}"/>
+        public Task<T> AsTask()
+        {
+            return Task.Run(() =>
+            {
+                while (!_aborted && _resolution == null) { }
+
+                if (_aborted)
+                {
+                    throw new OperationCanceledException();
+                }
+                
+                if (!_resolution.Success)
+                {
+                    throw _resolution.Exception;
+                }
+
+                return _resolution.Result;
+            });
         }
 
         /// <summary>

--- a/CreateAR.Commons.Unity.Async/AsyncToken.cs
+++ b/CreateAR.Commons.Unity.Async/AsyncToken.cs
@@ -201,11 +201,19 @@ namespace CreateAR.Commons.Unity.Async
         }
         
         /// <inheritdoc cref="IAsyncToken{T}"/>
-        public Task<T> AsTask()
+        public Task<T> AsTask(int timeoutMs = 30000)
         {
             return Task.Run(() =>
             {
-                while (!_aborted && _resolution == null) { }
+                var startTime = DateTime.Now;
+
+                while (!_aborted && _resolution == null)
+                {
+                    if ((DateTime.Now - startTime).TotalMilliseconds > timeoutMs)
+                    {
+                        Fail(new TimeoutException("Token task took too long to complete. Pass a larger value to AsTask(int timeoutMs) if the default timeout is too short."));
+                    }
+                }
 
                 if (_aborted)
                 {

--- a/CreateAR.Commons.Unity.Async/CreateAR.Commons.Unity.Async.csproj
+++ b/CreateAR.Commons.Unity.Async/CreateAR.Commons.Unity.Async.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>CreateAR.Commons.Unity.Async</AssemblyName>
     <RootNamespace>CreateAR.Commons.Unity.Async</RootNamespace>
     <AssemblyVersion>0.7.2</AssemblyVersion>
-    <Version>0.7.1</Version>
+    <Version>0.7.2</Version>
     <Description>Provides primitives for working asynchronously.</Description>
     <Copyright>Copyright © 2017 CreateAR</Copyright>
     <Authors>CreateAR</Authors>

--- a/CreateAR.Commons.Unity.Async/CreateAR.Commons.Unity.Async.csproj
+++ b/CreateAR.Commons.Unity.Async/CreateAR.Commons.Unity.Async.csproj
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <AssemblyName>CreateAR.Commons.Unity.Async</AssemblyName>
     <RootNamespace>CreateAR.Commons.Unity.Async</RootNamespace>
-    <AssemblyVersion>0.7.1</AssemblyVersion>
+    <AssemblyVersion>0.7.2</AssemblyVersion>
     <Version>0.7.1</Version>
     <Description>Provides primitives for working asynchronously.</Description>
     <Copyright>Copyright © 2017 CreateAR</Copyright>
     <Authors>CreateAR</Authors>
     <IncludeSymbols>True</IncludeSymbols>
-    <PackageReleaseNotes>Added All method to Async static class.
-Added Map to IAsyncToken.</PackageReleaseNotes>
-    <FileVersion>0.7.1</FileVersion>
+    <PackageReleaseNotes>Added AsTask for support with async/await.</PackageReleaseNotes>
+    <FileVersion>0.7.2</FileVersion>
     <PackageId>CreateAR.Commons.Unity.Async</PackageId>
+    <PackageVersion>0.7.2</PackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>

--- a/CreateAR.Commons.Unity.Async/IAsyncToken.cs
+++ b/CreateAR.Commons.Unity.Async/IAsyncToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace CreateAR.Commons.Unity.Async
 {
@@ -50,5 +51,12 @@ namespace CreateAR.Commons.Unity.Async
         /// <param name="map">Function to map between types.</param>
         /// <returns></returns>
         IAsyncToken<TR> Map<TR>(Func<T, TR> map);
+
+        /// <summary>
+        /// Converts the token into a task that can be awaited.
+        /// An aborted token throws an OperationCanceledException instance.
+        /// </summary>
+        /// <returns></returns>
+        Task<T> AsTask();
     }
 }

--- a/CreateAR.Commons.Unity.Async/IAsyncToken.cs
+++ b/CreateAR.Commons.Unity.Async/IAsyncToken.cs
@@ -57,6 +57,7 @@ namespace CreateAR.Commons.Unity.Async
         /// An aborted token throws an OperationCanceledException instance.
         /// </summary>
         /// <returns></returns>
-        Task<T> AsTask();
+        /// <param name="timeoutMs">The time to wait for the task to complete before failing.</param>
+        Task<T> AsTask(int timeoutMs = 30000);
     }
 }


### PR DESCRIPTION
Tokens can now be converted into tasks which watch their success/failure/abortion. Conforms with standard Task expectations, like throwing `OperationCanceledException` when the underlying token has been aborted.

Using tokens as tasks can be especially useful where tokens would normally be chained together. For comparison:

Chained Tokens
```
private IAsyncToken<Void> FetchAndLoad(string url)
{
	var rtnToken = new AsyncToken<Void>();

	network
		.GetFile(url)
		.OnSuccess(compressedBytes => 
		{
			inflator
				.decompress(compressedBytes)
					.OnSuccess(bytes => 
					{
						loader
							.load(bytes)
								.OnSuccess(rtnToken.Succeed)
								.onFailure(rtnToken.Fail)
					})
					.onFailure(rtnToken.Fail)

		})
		.onFailure(rtnToken.Fail);

	return rtnToken;
}


FetchAndLoad(url)
	.OnSuccess(_ => {
		...
	})
	.onFailure(exception => {
		...
	});
```


Async/Await
```
private Task FetchAndLoad(string url) 
{
	var compressedBytes = await network.GetFile(url).AsTask();
	var bytes = await inflator.decompress(compressedBytes).AsTask();
	await loader.load(bytes).AsTask();
}

try 
{
	await FetchAndLoad(url);
} 
catch (Exception exception) 
{
	...
}

...
```