### PR TITLE
Add overload for AsTask for passing in a CancellationToken

### DIFF
--- a/CreateAR.Commons.Unity.Async/IAsyncToken.cs
+++ b/CreateAR.Commons.Unity.Async/IAsyncToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CreateAR.Commons.Unity.Async
@@ -55,9 +56,20 @@ namespace CreateAR.Commons.Unity.Async
         /// <summary>
         /// Converts the token into a task that can be awaited.
         /// An aborted token throws an OperationCanceledException instance.
+        /// A task that times out also fails the underlying token for parity.
         /// </summary>
         /// <returns></returns>
         /// <param name="timeoutMs">The time to wait for the task to complete before failing.</param>
         Task<T> AsTask(int timeoutMs = 30000);
+
+        /// <summary>
+        /// Converts the token into a task that can be awaited.
+        /// An aborted token throws an OperationCanceledException instance.
+        /// A task that is cancelled does not fail the underlying token, for parity with Abort().
+        /// </summary>
+        /// <returns></returns>
+        /// <param name="timeoutMs">The time to wait for the task to complete before failing.</param>
+        /// <param name="cancellationToken">Custom cancellation.</param>
+        Task<T> AsTask(CancellationToken cancellationToken, int timeoutMs = 30000);
     }
 }


### PR DESCRIPTION
Title says it all. Using a CancellationToken aborts the underlying token instead of failing it. The assumption being that a try/catch around a task that can fail will likely noop the cancellation, similar to how the underlying token would handle a cancellation via Abort().