### PR TITLE
Provide actual stack traces.

### DIFF
--- a/CreateAR.Commons.Unity.Async/CreateAR.Commons.Unity.Async.csproj
+++ b/CreateAR.Commons.Unity.Async/CreateAR.Commons.Unity.Async.csproj
@@ -4,16 +4,17 @@
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>CreateAR.Commons.Unity.Async</AssemblyName>
     <RootNamespace>CreateAR.Commons.Unity.Async</RootNamespace>
-    <AssemblyVersion>0.7.2</AssemblyVersion>
+    <AssemblyVersion>0.7.3</AssemblyVersion>
     <Version>0.7.2</Version>
     <Description>Provides primitives for working asynchronously.</Description>
-    <Copyright>Copyright © 2017 CreateAR</Copyright>
-    <Authors>CreateAR</Authors>
+    <Copyright>Copyright © 2020 Enklu</Copyright>
+    <Authors>Enklu</Authors>
     <IncludeSymbols>True</IncludeSymbols>
-    <PackageReleaseNotes>Added AsTask for support with async/await.</PackageReleaseNotes>
-    <FileVersion>0.7.2</FileVersion>
+    <PackageReleaseNotes>Better exception visibility.</PackageReleaseNotes>
+    <FileVersion>0.7.3</FileVersion>
     <PackageId>CreateAR.Commons.Unity.Async</PackageId>
-    <PackageVersion>0.7.2</PackageVersion>
+    <PackageVersion>0.7.3</PackageVersion>
+    <Company>Enklu</Company>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>


### PR DESCRIPTION
Use ExceptionDispatchInfo to actually have useful stack traces for nested token usage failure. When dealing with aggregate exceptions, it will still be tricky since those will ultimately be rethrown. But for now, better than nothing!

Before:
![image](https://user-images.githubusercontent.com/4741738/89242368-3b11ae00-d5b6-11ea-9bb4-5d42935ee283.png)

After:
![image](https://user-images.githubusercontent.com/4741738/89242372-3f3dcb80-d5b6-11ea-8076-131a9cc3bfe0.png)
